### PR TITLE
Fixed ValidatorSetHbbft Unit Tests

### DIFF
--- a/contracts/base/StakingHbbftBase.sol
+++ b/contracts/base/StakingHbbftBase.sol
@@ -863,10 +863,9 @@ contract StakingHbbftBase is UpgradeableOwned, IStakingHbbft {
         require(!isInitialized()); // initialization can only be done once
         require(_validatorSetContract != address(0));
         require(_initialStakingAddresses.length > 0);
-        require(_initialStakingAddresses.length == _publicKeys.length);
-        require(_publicKeys.length == _internetAddresses.length);
-        require(_initialStakingAddresses.length == _publicKeys.length.mul(2));
+        require(_initialStakingAddresses.length.mul(2) == _publicKeys.length);
         require(_initialStakingAddresses.length == _internetAddresses.length);
+        require(_publicKeys.length == _internetAddresses.length.mul(2));
         require(_delegatorMinStake != 0);
         require(_candidateMinStake != 0);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5157,9 +5157,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.isfunction": {
       "version": "3.0.9",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/poanetwork/posdao-contracts#readme",
   "dependencies": {
+    "lodash": "^4.17.15",
     "solidity-docgen": "0.1.1",
     "solidity-flattener": "github:poanetwork/solidity-flattener#master"
   },

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -27,7 +27,7 @@ start_ganache() {
   if [ "$SOLIDITY_COVERAGE" = true ]; then
     node_modules/.bin/testrpc-sc --gasLimit 0xfffffffffff --port "$ganache_port" --accounts 200 --defaultBalanceEther 1000000 > /dev/null &
   else
-    node_modules/.bin/ganache-cli --gasLimit 0xfffffffffff --port "$ganache_port" --accounts 200 --defaultBalanceEther 1000000 > /dev/null &
+    node_modules/.bin/ganache-cli --gasLimit 0xfffffffffff --port "$ganache_port" --accounts 200 --defaultBalanceEther 1000000 --mnemonic "found era catch basic dce engine company actor impact fiess fresh food" > /dev/null &
   fi
 
   ganache_pid=$!

--- a/test/ValidatorSetHbbft.js
+++ b/test/ValidatorSetHbbft.js
@@ -8,6 +8,7 @@ const ValidatorSetHbbft = artifacts.require('ValidatorSetHbbftMock');
 const ERROR_MSG = 'VM Exception while processing transaction: revert';
 const BN = web3.utils.BN;
 
+const fp = require('lodash/fp');
 require('chai')
   .use(require('chai-as-promised'))
   .use(require('chai-bn')(BN))
@@ -18,6 +19,8 @@ contract('ValidatorSetHbbft', async accounts => {
   let blockRewardHbbft;
   let stakingHbbft;
   let validatorSetHbbft;
+  let initialValidatorsPubKeys;
+  let initialValidatorsIpAddresses;
 
   beforeEach(async () => {
     owner = accounts[0];
@@ -33,6 +36,16 @@ contract('ValidatorSetHbbft', async accounts => {
     validatorSetHbbft = await ValidatorSetHbbft.new();
     validatorSetHbbft = await AdminUpgradeabilityProxy.new(validatorSetHbbft.address, owner, []);
     validatorSetHbbft = await ValidatorSetHbbft.at(validatorSetHbbft.address);
+
+    // The following private keys belong to the accounts 1-3, fixed by using the "--mnemonic" option when starting ganache.
+    // const initialValidatorsPrivKeys = ["0x272b8400a202c08e23641b53368d603e5fec5c13ea2f438bce291f7be63a02a7", "0xa8ea110ffc8fe68a069c8a460ad6b9698b09e21ad5503285f633b3ad79076cf7", "0x5da461ff1378256f69cb9a9d0a8b370c97c460acbe88f5d897cb17209f891ffc"];
+    // Public keys corresponding to the three private keys above.
+    initialValidatorsPubKeys = fp.flatMap(x => [x.substring(0, 34), '0x' + x.substring(34, 66)])
+      (['0x52be8f332b0404dff35dd0b2ba44993a9d3dc8e770b9ce19a849dff948f1e14c57e7c8219d522c1a4cce775adbee5330f222520f0afdabfdb4a4501ceeb8dcee',
+        '0x99edf3f524a6f73e7f5d561d0030fc6bcc3e4bd33971715617de7791e12d9bdf6258fa65b74e7161bbbf7ab36161260f56f68336a6f65599dc37e7f2e397f845',
+        '0xa255fd7ad199f0ee814ee00cce44ef2b1fa1b52eead5d8013ed85eade03034ae4c246658946c2e1d7ded96394a1247fb4d093c32474317ae388e8d25692a0f56']);
+    // The IP addresses are irrelevant for these unit test, just initialize them to 0.
+    initialValidatorsIpAddresses = ['0x00000000000000000000000000000000', '0x00000000000000000000000000000000', '0x00000000000000000000000000000000'];
   });
 
   describe('clearUnremovableValidator()', async () => {
@@ -79,7 +92,9 @@ contract('ValidatorSetHbbft', async accounts => {
         web3.utils.toWei('1', 'ether'), // _candidateMinStake
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
-        4320 // _stakeWithdrawDisallowPeriod
+        4320, // _stakeWithdrawDisallowPeriod
+        initialValidatorsPubKeys, // _publicKeys
+        initialValidatorsIpAddresses // _internetAddresses
       ).should.be.fulfilled;
 
       // Deploy ERC677 contract
@@ -122,7 +137,9 @@ contract('ValidatorSetHbbft', async accounts => {
         web3.utils.toWei('1', 'ether'), // _candidateMinStake
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
-        4320 // _stakeWithdrawDisallowPeriod
+        4320, // _stakeWithdrawDisallowPeriod
+        initialValidatorsPubKeys, // _publicKeys
+        initialValidatorsIpAddresses // _internetAddresses
       ).should.be.fulfilled;
       (await stakingHbbft.getPoolsToBeRemoved.call()).should.be.deep.equal([
         initialStakingAddresses[1],
@@ -167,7 +184,9 @@ contract('ValidatorSetHbbft', async accounts => {
         web3.utils.toWei('1', 'ether'), // _candidateMinStake
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
-        4320 // _stakeWithdrawDisallowPeriod
+        4320, // _stakeWithdrawDisallowPeriod
+        initialValidatorsPubKeys, // _publicKeys
+        initialValidatorsIpAddresses // _internetAddresses
       ).should.be.fulfilled;
 
       // Set `initiateChangeAllowed` boolean flag to `true`
@@ -427,7 +446,9 @@ contract('ValidatorSetHbbft', async accounts => {
         web3.utils.toWei('1', 'ether'), // _candidateMinStake
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
-        4320 // _stakeWithdrawDisallowPeriod
+        4320, // _stakeWithdrawDisallowPeriod
+        initialValidatorsPubKeys, // _publicKeys
+        initialValidatorsIpAddresses // _internetAddresses
       ).should.be.fulfilled;
       await stakingHbbft.setCurrentBlockNumber(120954).should.be.fulfilled;
       await validatorSetHbbft.setCurrentBlockNumber(120954).should.be.fulfilled;
@@ -550,7 +571,9 @@ contract('ValidatorSetHbbft', async accounts => {
         web3.utils.toWei('1', 'ether'), // _candidateMinStake
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
-        4320 // _stakeWithdrawDisallowPeriod
+        4320, // _stakeWithdrawDisallowPeriod
+        initialValidatorsPubKeys, // _publicKeys
+        initialValidatorsIpAddresses // _internetAddresses
       ).should.be.fulfilled;
       await stakingHbbft.setValidatorSetAddress(validatorSetHbbft.address).should.be.fulfilled;
 
@@ -645,7 +668,13 @@ contract('ValidatorSetHbbft', async accounts => {
       await validatorSetHbbft.setCurrentBlockNumber(30).should.be.fulfilled;
       for (let i = 0; i < stakingAddresses.length; i++) {
         const stakeAmount = stakeUnit.mul(new BN(i + 1));
-        await stakingHbbft.addPool(stakeAmount, miningAddresses[i], {from: stakingAddresses[i]}).should.be.fulfilled;
+        await stakingHbbft.addPool( 
+          stakeAmount, 
+          miningAddresses[i], 
+          '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+          '0x00000000000000000000000000000000',
+          {from: stakingAddresses[i]}
+        ).should.be.fulfilled;
         stakeAmount.should.be.bignumber.equal(await stakingHbbft.stakeAmount.call(stakingAddresses[i], stakingAddresses[i]));
       }
 
@@ -711,7 +740,9 @@ contract('ValidatorSetHbbft', async accounts => {
         web3.utils.toWei('1', 'ether'), // _candidateMinStake
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
-        4320 // _stakeWithdrawDisallowPeriod
+        4320, // _stakeWithdrawDisallowPeriod
+        initialValidatorsPubKeys, // _publicKeys
+        initialValidatorsIpAddresses // _internetAddresses
       ).should.be.fulfilled;
       await stakingHbbft.setValidatorSetAddress(validatorSetHbbft.address).should.be.fulfilled;
 
@@ -759,7 +790,13 @@ contract('ValidatorSetHbbft', async accounts => {
       await validatorSetHbbft.setCurrentBlockNumber(30).should.be.fulfilled;
       for (let i = 0; i < stakingAddresses.length; i++) {
         const stakeAmount = stakeUnit.mul(new BN(i + 1));
-        await stakingHbbft.addPool(stakeAmount, miningAddresses[i], {from: stakingAddresses[i]}).should.be.fulfilled;
+        await stakingHbbft.addPool(
+          stakeAmount,           
+          miningAddresses[i], 
+          '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+          '0x00000000000000000000000000000000',
+          {from: stakingAddresses[i]}
+        ).should.be.fulfilled;
         stakeAmount.should.be.bignumber.equal(await stakingHbbft.stakeAmount.call(stakingAddresses[i], stakingAddresses[i]));
       }
 


### PR DESCRIPTION
A couple of the unit tests were failing due to missing contract function call arguments.

Used the "--mnemonic" option in test.sh to be able to use the validators' public keys in unit tests and supplied the validators' public keys and IP addresses to relevant contract function calls.