### PR TITLE
fix(CON-01/GLOBAL-01): separate proxy admin from operational owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,9 @@ Once flattened, the contracts are available in the `flat` directory.
 
 The reference (and audit-scope) initialization path is **genesis + `InitializerAuRa`**
 (`block.number == 0`). At genesis the `initialize()` block-number guard is bypassed and
-`InitializerAuRa` passes an explicit operational owner to every contract, so the issue2
-admin/owner separation (`_owner != _admin()`) is satisfied by construction. CON-01 /
+`InitializerAuRa` passes an explicit operational owner to the owner-managed contracts
+affected by issue2, so the issue2 admin/owner separation (`_owner != _admin()`) is
+satisfied by construction. CON-01 /
 GLOBAL-01 / issue2 deploy correctness should be judged against this path.
 
 `scripts/deploy_for_xdai.js` is a **legacy one-off live-chain script and is NOT part of

--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ Once flattened, the contracts are available in the `flat` directory.
 ### Deployment
 
 The reference (and audit-scope) initialization path is **genesis + `InitializerAuRa`**
-(`block.number == 0`). At genesis the `initialize()` block-number guard is bypassed and
+(`block.number == 0`). At genesis the `initialize()` block-number guard is bypassed.
 `InitializerAuRa` passes an explicit operational owner to the owner-managed contracts
-affected by issue2, so the issue2 admin/owner separation (`_owner != _admin()`) is
-satisfied by construction. CON-01 /
+affected by issue2, and each affected initializer enforces `_owner != _admin()`, so the
+admin/owner separation is enforced during genesis initialization. CON-01 /
 GLOBAL-01 / issue2 deploy correctness should be judged against this path.
 
 `scripts/deploy_for_xdai.js` is a **legacy one-off live-chain script and is NOT part of
@@ -163,11 +163,12 @@ prevents the admin from reaching implementation functions via the fallback, so t
 operational owner to differ from the proxy admin, which a single-key setup cannot
 satisfy. This script is retained for historical reference only.
 
-A working **live redeploy** (as opposed to genesis) is out of scope for the issue2 PR and
-will be handled separately. It requires distinct proxy-admin / operational-owner / signer
-roles and must initialize each proxy via `upgradeToAndCall(impl, initCalldata)` from the
-admin (an admin-only path that bypasses the fallback block), passing an operational owner
-distinct from the admin.
+A working **live redeploy** (as opposed to genesis) is out of scope for the issue2
+PR and will be handled separately. It requires distinct proxy-admin /
+operational-owner / signer roles. The admin must initialize through
+`upgradeToAndCall(impl, initCalldata)` rather than the proxy fallback, and the
+initCalldata for the issue2-affected owner-managed contracts must include an
+operational owner distinct from the proxy admin.
 
 ## Security Audit
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,29 @@ $ npm run flat
 
 Once flattened, the contracts are available in the `flat` directory.
 
+### Deployment
+
+The reference (and audit-scope) initialization path is **genesis + `InitializerAuRa`**
+(`block.number == 0`). At genesis the `initialize()` block-number guard is bypassed and
+`InitializerAuRa` passes an explicit operational owner to every contract, so the issue2
+admin/owner separation (`_owner != _admin()`) is satisfied by construction. CON-01 /
+GLOBAL-01 / issue2 deploy correctness should be judged against this path.
+
+`scripts/deploy_for_xdai.js` is a **legacy one-off live-chain script and is NOT part of
+the audit-scope deploy flow.** It is non-functional against the current transparent-proxy
+code: it uses a single key as proxy admin, operational owner, and tx signer, and calls
+`initialize()` through the proxy fallback. The UPG-01 transparent proxy admin-block
+prevents the admin from reaching implementation functions via the fallback, so the first
+`initialize()` reverts — independently of issue2. issue2 additionally requires the
+operational owner to differ from the proxy admin, which a single-key setup cannot
+satisfy. This script is retained for historical reference only.
+
+A working **live redeploy** (as opposed to genesis) is out of scope for the issue2 PR and
+will be handled separately. It requires distinct proxy-admin / operational-owner / signer
+roles and must initialize each proxy via `upgradeToAndCall(impl, initCalldata)` from the
+admin (an admin-only path that bypasses the fallback block), passing an operational owner
+distinct from the admin.
+
 ## Security Audit
 
 - [Code Assessment of the POSDAO Smart Contracts](https://github.com/poanetwork/posdao-contracts/blob/master/audit/ChainSecurity/report.pdf) by ChainSecurity

--- a/contracts/Certifier.sol
+++ b/contracts/Certifier.sol
@@ -57,6 +57,7 @@ contract Certifier is UpgradeableOwned, ICertifier {
             _certify(_certifiedAddresses[i]);
         }
         validatorSetContract = IValidatorSetAuRa(_validatorSet);
+        _setOwner(_admin());
     }
 
     /// @dev Allows the specified addresses to use a zero gas price for their transactions.

--- a/contracts/Certifier.sol
+++ b/contracts/Certifier.sol
@@ -48,7 +48,8 @@ contract Certifier is UpgradeableOwned, ICertifier {
     /// @param _validatorSet The address of the `ValidatorSetAuRa` contract.
     function initialize(
         address[] calldata _certifiedAddresses,
-        address _validatorSet
+        address _validatorSet,
+        address _owner
     ) external {
         require(block.number == 0 || msg.sender == _admin());
         require(!isInitialized());
@@ -57,7 +58,12 @@ contract Certifier is UpgradeableOwned, ICertifier {
             _certify(_certifiedAddresses[i]);
         }
         validatorSetContract = IValidatorSetAuRa(_validatorSet);
-        _setOwner(_admin());
+        // Operational owner must be distinct from the proxy admin: the transparent proxy
+        // blocks the admin from calling implementation functions, so owner == admin would
+        // permanently lock every `onlyOwner` function.
+        require(_owner != address(0));
+        require(_owner != _admin());
+        _setOwner(_owner);
     }
 
     /// @dev Allows the specified addresses to use a zero gas price for their transactions.

--- a/contracts/ERC677BridgeTokenRewardable.sol
+++ b/contracts/ERC677BridgeTokenRewardable.sol
@@ -331,17 +331,16 @@ contract Ownable {
 
   /**
    * @dev Allows the current owner to renounce onwership.
-   * @param _newOwner The address to transfer ownership to.
    */
   function renounceOwnership() public onlyOwner {
-      _owner = address(0);
+      owner = address(0);
       pendingOwner = address(0);
-      emit OwnershipTransferred(_owner, address(0));
+      emit OwnershipTransferred(owner, address(0));
   }
 
   /**
    * @dev Allows the current owner to transfer control of the contract to a newOwner.
-   * @param _newOwner The address to transfer ownership to.
+   * @param newOwner The address to transfer ownership to.
    */
   function transferOwnership(address newOwner) public onlyOwner {
       require(address(0) != newOwner, "pendingOwner set to the zero address.");
@@ -350,14 +349,13 @@ contract Ownable {
 
   /**
    * @dev Allows the newOwner to transfer control of the contract to a newOwner.
-   * @param _newOwner The address to transfer ownership to.
    */
   function claimOwnership() public {
       require(msg.sender == pendingOwner, "caller != pending owner");
 
-      _owner = pendingOwner;
+      owner = pendingOwner;
       pendingOwner = address(0);
-      emit OwnershipTransferred(_owner, pendingOwner);
+      emit OwnershipTransferred(owner, pendingOwner);
   }
 
   /**
@@ -788,6 +786,7 @@ contract ERC677MultiBridgeToken is PermittableToken {
 
     event BridgeAdded(address indexed bridge);
     event BridgeRemoved(address indexed bridge);
+    event blockRewardContractSet(address indexed blockRewardContract);
 
     constructor(
         string memory _name,
@@ -879,6 +878,8 @@ contract ERC677BridgeTokenRewardable is ERC677MultiBridgeToken {
     address public blockRewardContract;
     address public stakingContract;
 
+    event stakingContractSet(address indexed stakingContract);
+
     constructor(
         string memory _name,
         string memory _symbol,
@@ -891,12 +892,14 @@ contract ERC677BridgeTokenRewardable is ERC677MultiBridgeToken {
     function setBlockRewardContract(address _blockRewardContract) external onlyOwner {
         require(AddressUtils.isContract(_blockRewardContract));
         blockRewardContract = _blockRewardContract;
+        emit blockRewardContractSet(_blockRewardContract);
     }
 
     function setStakingContract(address _stakingContract) external onlyOwner {
         require(AddressUtils.isContract(_stakingContract));
         require(balanceOf(_stakingContract) == 0);
         stakingContract = _stakingContract;
+        emit stakingContractSet(_stakingContract);
     }
 
     modifier onlyBlockRewardContract() {

--- a/contracts/ERC677BridgeTokenRewardable.sol
+++ b/contracts/ERC677BridgeTokenRewardable.sol
@@ -304,6 +304,7 @@ contract StandardToken is ERC20, BasicToken {
  */
 contract Ownable {
   address public owner;
+  address public pendingOwner;
 
 
   event OwnershipTransferred(
@@ -329,11 +330,34 @@ contract Ownable {
   }
 
   /**
+   * @dev Allows the current owner to renounce onwership.
+   * @param _newOwner The address to transfer ownership to.
+   */
+  function renounceOwnership() public onlyOwner {
+      _owner = address(0);
+      pendingOwner = address(0);
+      emit OwnershipTransferred(_owner, address(0));
+  }
+
+  /**
    * @dev Allows the current owner to transfer control of the contract to a newOwner.
    * @param _newOwner The address to transfer ownership to.
    */
-  function transferOwnership(address _newOwner) public onlyOwner {
-    _transferOwnership(_newOwner);
+  function transferOwnership(address newOwner) public onlyOwner {
+      require(address(0) != newOwner, "pendingOwner set to the zero address.");
+      pendingOwner = newOwner;
+  }
+
+  /**
+   * @dev Allows the newOwner to transfer control of the contract to a newOwner.
+   * @param _newOwner The address to transfer ownership to.
+   */
+  function claimOwnership() public {
+      require(msg.sender == pendingOwner, "caller != pending owner");
+
+      _owner = pendingOwner;
+      pendingOwner = address(0);
+      emit OwnershipTransferred(_owner, pendingOwner);
   }
 
   /**

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -432,4 +432,5 @@ contract Governance is UpgradeableOwned, BanReasons, IGovernance {
         return block.number;
     }
 
+    uint256[128] __gap;
 }

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -380,7 +380,7 @@ contract Governance is UpgradeableOwned, BanReasons, IGovernance {
         uint256 creatorPoolId = ballotCreator[_ballotId];
         uint256 targetPoolId = ballotPoolId[_ballotId];
         ballotResult[_ballotId] = result;
-        ballotStatus[_ballotId] == BALLOT_STATUS_FINALIZED;
+        ballotStatus[_ballotId] = BALLOT_STATUS_FINALIZED;
         openCountPerPoolId[creatorPoolId] = openCountPerPoolId[creatorPoolId].sub(1);
         if (result == BALLOT_RESULT_REMOVE) {
             validatorSetContract.removeValidator(

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -297,6 +297,10 @@ contract Governance is UpgradeableOwned, BanReasons, IGovernance {
             if (keepVotesCount.add(removeVotesCount).add(banVotesCount) >= validatorsLength) {
                 return true;
             }
+            // New criterion: Ensure that at least 2/3 of the validators have voted.
+            if (keepVotesCount.add(removeVotesCount).add(banVotesCount) >= (validatorsLength * 2) / 3) {
+                return true;
+            }
         }
         return false;
     }

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -414,11 +414,28 @@ contract Governance is UpgradeableOwned, BanReasons, IGovernance {
 
         uint256 result = BALLOT_RESULT_KEEP;
 
+        // sorting remove , keep, ban => 3! = 6
+        // -------------------
+        // remove, keep, ban
+        // remove, ban, keep
+        // keep, remove , ban
+        // keep, ban, remove
+        // ban, remove, keep
+        // ban, keep, remove
+        // -------------------
+        // > or =
+        // >>, >=, =>, ==
+        // special case exist on A=B>C & A=B=C
+        // keep = ban > remove : might be keep
+        // keep = remove > ban : might be keep
+        // ban = remove > keep : tie, but might be keep (becuase keep > ban - remove)
+        // remove = keep = ban : tie, but might be keep (becuase keep > ban - remove)
+
         if (removeVotesCount > banVotesCount) {
             if (removeVotesCount > keepVotesCount) {
                 result = BALLOT_RESULT_REMOVE;
             }
-        } else {
+        } else { // removeVotesCount <= banVotesCount
             if (banVotesCount > removeVotesCount && banVotesCount > keepVotesCount) {
                 result = BALLOT_RESULT_BAN;
             }

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -418,33 +418,11 @@ contract Governance is UpgradeableOwned, BanReasons, IGovernance {
 
         uint256 result = BALLOT_RESULT_KEEP;
 
-        // sorting remove , keep, ban => 3! = 6
-        // -------------------
-        // remove, keep, ban
-        // remove, ban, keep
-        // keep, remove , ban
-        // keep, ban, remove
-        // ban, remove, keep
-        // ban, keep, remove
-        // -------------------
-        // > or =
-        // >>, >=, =>, ==
-        // special case exist on A=B>C & A=B=C
-        // keep = ban > remove : might be keep
-        // keep = remove > ban : might be keep
-        // ban = remove > keep : tie, but might be keep (becuase keep > ban - remove)
-        // remove = keep = ban : tie, but might be keep (becuase keep > ban - remove)
-
-        if (removeVotesCount > banVotesCount) {
-            if (removeVotesCount > keepVotesCount) {
-                result = BALLOT_RESULT_REMOVE;
-            }
-        } else { // removeVotesCount <= banVotesCount
-            if (banVotesCount > removeVotesCount && banVotesCount > keepVotesCount) {
-                result = BALLOT_RESULT_BAN;
-            }
+        if (removeVotesCount >= banVotesCount && removeVotesCount > keepVotesCount) {
+            result = BALLOT_RESULT_REMOVE;
+        } else if (banVotesCount >= removeVotesCount && banVotesCount > keepVotesCount) {
+            result = BALLOT_RESULT_BAN;
         }
-
         return result;
     }
 

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -138,6 +138,7 @@ contract Governance is UpgradeableOwned, BanReasons, IGovernance {
         require(validatorSetContract == IValidatorSetAuRa(0));
         require(_validatorSetContract != address(0));
         validatorSetContract = IValidatorSetAuRa(_validatorSetContract);
+        _setOwner(_admin());
     }
 
     /// @dev Creates a new ballot.

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -133,12 +133,17 @@ contract Governance is UpgradeableOwned, BanReasons, IGovernance {
     /// @dev Initializes the contract. Used by the constructor of the `InitializerAuRa` contract, or separately when
     /// initializing not from genesis.
     /// @param _validatorSetContract The address of the `ValidatorSetAuRa` contract.
-    function initialize(address _validatorSetContract) external {
+    function initialize(address _validatorSetContract, address _owner) external {
         require(_getCurrentBlockNumber() == 0 || msg.sender == _admin());
         require(validatorSetContract == IValidatorSetAuRa(0));
         require(_validatorSetContract != address(0));
         validatorSetContract = IValidatorSetAuRa(_validatorSetContract);
-        _setOwner(_admin());
+        // Operational owner must be distinct from the proxy admin: the transparent proxy
+        // blocks the admin from calling implementation functions, so owner == admin would
+        // permanently lock every `onlyOwner` function.
+        require(_owner != address(0));
+        require(_owner != _admin());
+        _setOwner(_owner);
     }
 
     /// @dev Creates a new ballot.

--- a/contracts/InitializerAuRa.sol
+++ b/contracts/InitializerAuRa.sol
@@ -62,29 +62,17 @@ contract InitializerAuRa {
             _stakingAddresses,
             _firstValidatorIsUnremovable
         );
-        {
-            uint256[] memory _ids = new uint256[](_stakingAddresses.length);
-            for (uint256 i = 0; i < _ids.length; i++) {
-                _ids[i] = IValidatorSetAuRa(_contracts[0]).idByStakingAddress(_stakingAddresses[i]);
-            }
-            IStakingAuRa(_contracts[3]).initialize(
-                _contracts[0], // _validatorSetContract
-                _contracts[6], // _governanceContract
-                _ids,
-                _delegatorMinStake,
-                _candidateMinStake,
-                _stakingEpochDuration,
-                _stakingEpochStartBlock,
-                _stakeWithdrawDisallowPeriod
-            );
-        }
-        IBlockRewardAuRa(_contracts[1]).initialize(_contracts[0], address(0));
-        IRandomAuRa(_contracts[2]).initialize(_collectRoundLength, _contracts[0], true);
-        address[] memory permittedAddresses = new address[](1);
-        permittedAddresses[0] = _owner;
-        ITxPermission(_contracts[4]).initialize(permittedAddresses, _contracts[5], _contracts[0]);
-        ICertifier(_contracts[5]).initialize(permittedAddresses, _contracts[0]);
-        IGovernance(_contracts[6]).initialize(_contracts[0]);
+        // Extracted into a private function (and the numeric params packed into a fixed array)
+        // to keep the stack within Solidity 0.5.x limits after adding the operational owner arg.
+        uint256[5] memory _stakingParams;
+        _stakingParams[0] = _delegatorMinStake;
+        _stakingParams[1] = _candidateMinStake;
+        _stakingParams[2] = _stakingEpochDuration;
+        _stakingParams[3] = _stakingEpochStartBlock;
+        _stakingParams[4] = _stakeWithdrawDisallowPeriod;
+        _initStaking(_contracts, _owner, _stakingAddresses, _stakingParams);
+        // Remaining initializations are extracted to keep the constructor's stack within limits.
+        _initOthers(_contracts, _owner, _collectRoundLength);
         if (block.number > 0) {
             selfdestruct(msg.sender); // this is to clear the state
             // OpenEthereum and Nethermind clients
@@ -92,5 +80,45 @@ contract InitializerAuRa {
             // (see https://github.com/openethereum/openethereum/issues/184)
             // so we call `selfdestruct` here only if we are not in genesis
         }
+    }
+
+    /// @param _stakingParams Packed numeric parameters:
+    ///   [0] _delegatorMinStake, [1] _candidateMinStake, [2] _stakingEpochDuration,
+    ///   [3] _stakingEpochStartBlock, [4] _stakeWithdrawDisallowPeriod.
+    function _initStaking(
+        address[] memory _contracts,
+        address _owner,
+        address[] memory _stakingAddresses,
+        uint256[5] memory _stakingParams
+    ) private {
+        uint256[] memory _ids = new uint256[](_stakingAddresses.length);
+        for (uint256 i = 0; i < _ids.length; i++) {
+            _ids[i] = IValidatorSetAuRa(_contracts[0]).idByStakingAddress(_stakingAddresses[i]);
+        }
+        IStakingAuRa(_contracts[3]).initialize(
+            _contracts[0], // _validatorSetContract
+            _contracts[6], // _governanceContract
+            _ids,
+            _stakingParams[0],
+            _stakingParams[1],
+            _stakingParams[2],
+            _stakingParams[3],
+            _stakingParams[4],
+            _owner
+        );
+    }
+
+    function _initOthers(
+        address[] memory _contracts,
+        address _owner,
+        uint256 _collectRoundLength
+    ) private {
+        IBlockRewardAuRa(_contracts[1]).initialize(_contracts[0], address(0), _owner);
+        IRandomAuRa(_contracts[2]).initialize(_collectRoundLength, _contracts[0], true, _owner);
+        address[] memory permittedAddresses = new address[](1);
+        permittedAddresses[0] = _owner;
+        ITxPermission(_contracts[4]).initialize(permittedAddresses, _contracts[5], _contracts[0], _owner);
+        ICertifier(_contracts[5]).initialize(permittedAddresses, _contracts[0], _owner);
+        IGovernance(_contracts[6]).initialize(_contracts[0], _owner);
     }
 }

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -4,6 +4,8 @@ pragma solidity 0.5.10;
 contract Migrations {
     address public owner;
     uint public last_completed_migration; // solhint-disable-line
+    event Completed(uint completed);
+    event Upgraded(address new_address, uint last_completed_migration);
 
     constructor() public {
         owner = msg.sender;
@@ -15,10 +17,12 @@ contract Migrations {
 
     function setCompleted(uint completed) public restricted {
         last_completed_migration = completed;
+        emit Completed(completed);
     }
 
     function upgrade(address new_address) public restricted { // solhint-disable-line
         Migrations upgraded = Migrations(new_address);
         upgraded.setCompleted(last_completed_migration);
+        emit Upgraded(new_address, last_completed_migration);
     }
 }

--- a/contracts/RandomAuRa.sol
+++ b/contracts/RandomAuRa.sol
@@ -1,4 +1,5 @@
 pragma solidity 0.5.10;
+// Import necessary interfaces and functionality for upgradeable contracts.
 
 import "./interfaces/IRandomAuRa.sol";
 import "./interfaces/IStakingAuRa.sol";

--- a/contracts/RandomAuRa.sol
+++ b/contracts/RandomAuRa.sol
@@ -41,6 +41,8 @@ contract RandomAuRa is UpgradeableOwned, IRandomAuRa {
     /// @dev The address of the `ValidatorSetAuRa` contract.
     IValidatorSetAuRa public validatorSetContract;
 
+    event punishForUnrevealSet(bool punishForUnreveal);
+
     // ============================================== Modifiers =======================================================
 
     /// @dev Ensures the caller is the BlockRewardAuRa contract address.
@@ -148,6 +150,7 @@ contract RandomAuRa is UpgradeableOwned, IRandomAuRa {
     /// @dev Changes the `punishForUnreveal` boolean flag. Can only be called by an owner.
     function setPunishForUnreveal(bool _punishForUnreveal) external onlyOwner {
         punishForUnreveal = _punishForUnreveal;
+        emit punishForUnrevealSet(_punishForUnreveal);
     }
 
     /// @dev Initializes the contract at network startup.

--- a/contracts/RandomAuRa.sol
+++ b/contracts/RandomAuRa.sol
@@ -495,4 +495,6 @@ contract RandomAuRa is UpgradeableOwned, IRandomAuRa {
 
         return true;
     }
+
+    uint256[128] __gap;
 }

--- a/contracts/RandomAuRa.sol
+++ b/contracts/RandomAuRa.sol
@@ -176,6 +176,7 @@ contract RandomAuRa is UpgradeableOwned, IRandomAuRa {
         collectRoundLength = _collectRoundLength;
         validatorSetContract = IValidatorSetAuRa(_validatorSet);
         punishForUnreveal = _punishForUnreveal;
+        _setOwner(_admin());
     }
 
     /// @dev Checks whether the current validators at the end of each collection round revealed their numbers,

--- a/contracts/RandomAuRa.sol
+++ b/contracts/RandomAuRa.sol
@@ -162,7 +162,8 @@ contract RandomAuRa is UpgradeableOwned, IRandomAuRa {
     function initialize(
         uint256 _collectRoundLength, // in blocks
         address _validatorSet,
-        bool _punishForUnreveal
+        bool _punishForUnreveal,
+        address _owner
     ) external {
         require(_getCurrentBlockNumber() == 0 || msg.sender == _admin());
         require(!isInitialized());
@@ -176,7 +177,12 @@ contract RandomAuRa is UpgradeableOwned, IRandomAuRa {
         collectRoundLength = _collectRoundLength;
         validatorSetContract = IValidatorSetAuRa(_validatorSet);
         punishForUnreveal = _punishForUnreveal;
-        _setOwner(_admin());
+        // Operational owner must be distinct from the proxy admin: the transparent proxy
+        // blocks the admin from calling implementation functions, so owner == admin would
+        // permanently lock every `onlyOwner` function.
+        require(_owner != address(0));
+        require(_owner != _admin());
+        _setOwner(_owner);
     }
 
     /// @dev Checks whether the current validators at the end of each collection round revealed their numbers,

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -223,6 +223,7 @@ contract Registry is Owned, IMetadataRegistry, IOwnerRegistry, IReverseRegistry 
         onlyOwner
         returns (bool)
     {
+        requie(_amount <= 10000 ether, "should not be exceed more than 10,000 KONET");
         fee = _amount;
         emit FeeChanged(_amount);
         return true;

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -223,7 +223,7 @@ contract Registry is Owned, IMetadataRegistry, IOwnerRegistry, IReverseRegistry 
         onlyOwner
         returns (bool)
     {
-        requie(_amount <= 10000 ether, "should not be exceed more than 10,000 KONET");
+        require(_amount <= 10000 ether, "should not be exceed more than 10,000 KONET");
         fee = _amount;
         emit FeeChanged(_amount);
         return true;
@@ -249,7 +249,7 @@ contract Registry is Owned, IMetadataRegistry, IOwnerRegistry, IReverseRegistry 
         require(address(this).balance >= amount, "Address: insufficient balance");
 
         // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
-        (bool success, ) = recipient.call{ value: amount }("");
+        (bool success, ) = recipient.call.value(amount)("");
         require(success, "Address: unable to send value, recipient may have reverted");
     }
 
@@ -260,7 +260,8 @@ contract Registry is Owned, IMetadataRegistry, IOwnerRegistry, IReverseRegistry 
     {
         emit Drained(address(this).balance);
         //msg.sender.transfer(address(this).balance);
-        return sendValue(msg.sender, address(this).balance);
+        sendValue(msg.sender, address(this).balance);
+        return true;
     }
 
     // MetadataRegistry views

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -229,14 +229,38 @@ contract Registry is Owned, IMetadataRegistry, IOwnerRegistry, IReverseRegistry 
         return true;
     }
 
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
     function drain()
         external
         onlyOwner
         returns (bool)
     {
         emit Drained(address(this).balance);
-        msg.sender.transfer(address(this).balance);
-        return true;
+        //msg.sender.transfer(address(this).balance);
+        return sendValue(msg.sender, address(this).balance);
     }
 
     // MetadataRegistry views

--- a/contracts/base/BlockRewardAuRaBase.sol
+++ b/contracts/base/BlockRewardAuRaBase.sol
@@ -20,6 +20,8 @@ contract Sacrifice {
 contract BlockRewardAuRaBase is UpgradeableOwned, IBlockRewardAuRa {
     using SafeMath for uint256;
 
+    event ercToNativeBridgeAllowedSet(address bridge, bool allowed);
+
     // =============================================== Storage ========================================================
 
     // WARNING: since this contract is upgradeable, do not remove
@@ -340,12 +342,14 @@ contract BlockRewardAuRaBase is UpgradeableOwned, IBlockRewardAuRa {
 
         for (i = 0; i < _ercToNativeBridgesAllowed.length; i++) {
             _ercToNativeBridgeAllowed[_ercToNativeBridgesAllowed[i]] = false;
+            emit ercToNativeBridgeAllowedSet(_ercToNativeBridgesAllowed[i], false);
         }
 
         _ercToNativeBridgesAllowed = _bridgesAllowed;
 
         for (i = 0; i < _bridgesAllowed.length; i++) {
             _ercToNativeBridgeAllowed[_bridgesAllowed[i]] = true;
+            emit ercToNativeBridgeAllowedSet(_bridgesAllowed[i], true);
         }
     }
 

--- a/contracts/base/BlockRewardAuRaBase.sol
+++ b/contracts/base/BlockRewardAuRaBase.sol
@@ -217,14 +217,19 @@ contract BlockRewardAuRaBase is UpgradeableOwned, IBlockRewardAuRa {
     /// @param _validatorSet The address of the `ValidatorSetAuRa` contract.
     /// @param _prevBlockReward The address of the previous BlockReward contract
     /// (for statistics migration purposes).
-    function initialize(address _validatorSet, address _prevBlockReward) external {
+    function initialize(address _validatorSet, address _prevBlockReward, address _owner) external {
         require(_getCurrentBlockNumber() == 0 || msg.sender == _admin());
         require(!isInitialized());
         require(_validatorSet != address(0));
         validatorSetContract = IValidatorSetAuRa(_validatorSet);
         validatorMinRewardPercent[0] = VALIDATOR_MIN_REWARD_PERCENT;
         _prevBlockRewardContract = IBlockRewardAuRa(_prevBlockReward);
-        _setOwner(_admin());
+        // Operational owner must be distinct from the proxy admin: the transparent proxy
+        // blocks the admin from calling implementation functions, so owner == admin would
+        // permanently lock every `onlyOwner` function.
+        require(_owner != address(0));
+        require(_owner != _admin());
+        _setOwner(_owner);
     }
 
     /// @dev Called by the validator's node when producing and closing a block,

--- a/contracts/base/BlockRewardAuRaBase.sol
+++ b/contracts/base/BlockRewardAuRaBase.sol
@@ -224,6 +224,7 @@ contract BlockRewardAuRaBase is UpgradeableOwned, IBlockRewardAuRa {
         validatorSetContract = IValidatorSetAuRa(_validatorSet);
         validatorMinRewardPercent[0] = VALIDATOR_MIN_REWARD_PERCENT;
         _prevBlockRewardContract = IBlockRewardAuRa(_prevBlockReward);
+        _setOwner(_admin());
     }
 
     /// @dev Called by the validator's node when producing and closing a block,

--- a/contracts/base/BlockRewardAuRaTokens.sol
+++ b/contracts/base/BlockRewardAuRaTokens.sol
@@ -7,6 +7,9 @@ import "../interfaces/ITokenMinter.sol";
 
 
 contract BlockRewardAuRaTokens is BlockRewardAuRaBase, IBlockRewardAuRaTokens {
+    event ercToErcBridgeAllowed(address indexed bridge, bool allowed);
+    event nativeToErcBridgeAllowed(address indexed bridge, bool allowed);
+    event TokenMinterContractSet(address indexed tokenMinterContract);
 
     // =============================================== Storage ========================================================
 
@@ -88,12 +91,14 @@ contract BlockRewardAuRaTokens is BlockRewardAuRaBase, IBlockRewardAuRaTokens {
 
         for (i = 0; i < _ercToErcBridgesAllowed.length; i++) {
             _ercToErcBridgeAllowed[_ercToErcBridgesAllowed[i]] = false;
+            emit ercToErcBridgeAllowed(_ercToErcBridgesAllowed[i], false);
         }
 
         _ercToErcBridgesAllowed = _bridgesAllowed;
 
         for (i = 0; i < _bridgesAllowed.length; i++) {
             _ercToErcBridgeAllowed[_bridgesAllowed[i]] = true;
+            emit ercToErcBridgeAllowed(_bridgesAllowed[i], true);
         }
     }
 
@@ -105,12 +110,14 @@ contract BlockRewardAuRaTokens is BlockRewardAuRaBase, IBlockRewardAuRaTokens {
 
         for (i = 0; i < _nativeToErcBridgesAllowed.length; i++) {
             _nativeToErcBridgeAllowed[_nativeToErcBridgesAllowed[i]] = false;
+            emit nativeToErcBridgeAllowed(_nativeToErcBridgesAllowed[i], false);
         }
 
         _nativeToErcBridgesAllowed = _bridgesAllowed;
 
         for (i = 0; i < _bridgesAllowed.length; i++) {
             _nativeToErcBridgeAllowed[_bridgesAllowed[i]] = true;
+            emit nativeToErcBridgeAllowed(_bridgesAllowed[i], true);
         }
     }
 
@@ -122,6 +129,7 @@ contract BlockRewardAuRaTokens is BlockRewardAuRaBase, IBlockRewardAuRaTokens {
     /// as a minting contract.
     function setTokenMinterContract(ITokenMinter _tokenMinterContract) external onlyOwner onlyInitialized {
         tokenMinterContract = _tokenMinterContract;
+        emit TokenMinterContractSet(address(_tokenMinterContract));
     }
 
     /// @dev Called by the `StakingAuRa.claimReward` function to transfer tokens and native coins

--- a/contracts/base/StakingAuRaBase.sol
+++ b/contracts/base/StakingAuRaBase.sol
@@ -253,6 +253,10 @@ contract StakingAuRaBase is UpgradeableOwned, IStakingAuRa {
         uint256 fromPoolId
     );
 
+    event stakingEpochStartBlockSet(uint256 _blockNumber);
+    event candidateMinStakeUpdated(uint256 _candidateMinStake);
+    event delegatorMinStakeUpdated(uint256 _delegatorMinStake);
+
     // ============================================== Modifiers =======================================================
 
     /// @dev Ensures the transaction gas price is not zero.
@@ -455,6 +459,7 @@ contract StakingAuRaBase is UpgradeableOwned, IStakingAuRa {
     /// @param _blockNumber The number of the very first block in the upcoming staking epoch.
     function setStakingEpochStartBlock(uint256 _blockNumber) external onlyValidatorSetContract {
         stakingEpochStartBlock = _blockNumber;
+        emit stakingEpochStartBlockSet(_blockNumber);
     }
 
     /// @dev Moves staking tokens/coins from one pool to another. A staker calls this function when they want
@@ -650,6 +655,7 @@ contract StakingAuRaBase is UpgradeableOwned, IStakingAuRa {
     /// @param _minStake The value of a new limit in Wei.
     function setCandidateMinStake(uint256 _minStake) external onlyOwner onlyInitialized {
         candidateMinStake = _minStake;
+        emit candidateMinStakeUpdated(_minStake);
     }
 
     /// @dev Sets (updates) the limit of the minimum delegator stake (DELEGATOR_MIN_STAKE).
@@ -657,6 +663,7 @@ contract StakingAuRaBase is UpgradeableOwned, IStakingAuRa {
     /// @param _minStake The value of a new limit in Wei.
     function setDelegatorMinStake(uint256 _minStake) external onlyOwner onlyInitialized {
         delegatorMinStake = _minStake;
+        emit delegatorMinStakeUpdated(_minStake);
     }
 
     // =============================================== Getters ========================================================

--- a/contracts/base/StakingAuRaBase.sol
+++ b/contracts/base/StakingAuRaBase.sol
@@ -389,6 +389,7 @@ contract StakingAuRaBase is UpgradeableOwned, IStakingAuRa {
         stakingEpochStartBlock = _stakingEpochStartBlock;
         stakeWithdrawDisallowPeriod = _stakeWithdrawDisallowPeriod;
         lastChangeBlock = _getCurrentBlockNumber();
+        _setOwner(_admin());
     }
 
     /// @dev Makes initial validator stakes. Can only be called by the owner

--- a/contracts/base/StakingAuRaBase.sol
+++ b/contracts/base/StakingAuRaBase.sol
@@ -360,7 +360,8 @@ contract StakingAuRaBase is UpgradeableOwned, IStakingAuRa {
         uint256 _candidateMinStake,
         uint256 _stakingEpochDuration,
         uint256 _stakingEpochStartBlock,
-        uint256 _stakeWithdrawDisallowPeriod
+        uint256 _stakeWithdrawDisallowPeriod,
+        address _owner
     ) external {
         require(_validatorSetContract != address(0));
         require(_initialIds.length > 0);
@@ -389,7 +390,12 @@ contract StakingAuRaBase is UpgradeableOwned, IStakingAuRa {
         stakingEpochStartBlock = _stakingEpochStartBlock;
         stakeWithdrawDisallowPeriod = _stakeWithdrawDisallowPeriod;
         lastChangeBlock = _getCurrentBlockNumber();
-        _setOwner(_admin());
+        // Operational owner must be distinct from the proxy admin: the transparent proxy
+        // blocks the admin from calling implementation functions, so owner == admin would
+        // permanently lock every `onlyOwner` function.
+        require(_owner != address(0));
+        require(_owner != _admin());
+        _setOwner(_owner);
     }
 
     /// @dev Makes initial validator stakes. Can only be called by the owner

--- a/contracts/base/StakingAuRaCoins.sol
+++ b/contracts/base/StakingAuRaCoins.sol
@@ -74,7 +74,7 @@ contract StakingAuRaCoins is StakingAuRaBase {
             require(epoch < stakingEpoch);
 
             if (rewardWasTaken[poolId][delegatorOrZero][epoch]) continue;
-            
+
             uint256 reward;
 
             if (_poolStakingAddress != staker) { // this is a delegator
@@ -172,18 +172,17 @@ contract StakingAuRaCoins is StakingAuRaBase {
     }
 
     // ============================================== Internal ========================================================
-
     /// @dev Sends coins from this contract to the specified address.
     /// @param _to The target address to send amount to.
     /// @param _amount The amount to send.
     function _sendWithdrawnStakeAmount(address payable _to, uint256 _amount) internal gasPriceIsValid onlyInitialized {
+        require(_amount > 0, "Amount must be greater than zero");
+
+        require(address(this).balance >= _amount, "Insufficient contract balance");
+        lastChangeBlock = _getCurrentBlockNumber();
         if (!_to.send(_amount)) {
-            // We use the `Sacrifice` trick to be sure the coins can be 100% sent to the receiver.
-            // Otherwise, if the receiver is a contract which has a revert in its fallback function,
-            // the sending will fail.
             (new Sacrifice).value(_amount)(_to);
         }
-        lastChangeBlock = _getCurrentBlockNumber();
     }
 
     /// @dev The internal function used by the `stake` and `addPool` functions.

--- a/contracts/base/StakingAuRaTokens.sol
+++ b/contracts/base/StakingAuRaTokens.sol
@@ -89,7 +89,7 @@ contract StakingAuRaTokens is IStakingAuRaTokens, StakingAuRaBase {
             require(epoch < stakingEpoch);
 
             if (rewardWasTaken[poolId][delegatorOrZero][epoch]) continue;
-            
+
             RewardAmounts memory reward;
 
             if (_poolStakingAddress != staker) { // this is a delegator
@@ -267,13 +267,13 @@ contract StakingAuRaTokens is IStakingAuRaTokens, StakingAuRaBase {
                     poolId,
                     _staker
                 );
-                
+
                 firstLastEpoch[0] = _stakingEpochs[i] + 1; // firstEpoch = ...
 
-                (reward.tokenAmount, reward.nativeAmount) = 
+                (reward.tokenAmount, reward.nativeAmount) =
                     blockRewardContract.getDelegatorReward(delegatorStake, _stakingEpochs[i], poolId);
             } else { // this is a validator
-                (reward.tokenAmount, reward.nativeAmount) = 
+                (reward.tokenAmount, reward.nativeAmount) =
                     blockRewardContract.getValidatorReward(_stakingEpochs[i], poolId);
             }
 
@@ -290,9 +290,12 @@ contract StakingAuRaTokens is IStakingAuRaTokens, StakingAuRaBase {
     /// @param _to The target address to send amount to.
     /// @param _amount The amount to send.
     function _sendWithdrawnStakeAmount(address payable _to, uint256 _amount) internal gasPriceIsValid onlyInitialized {
-        require(erc677TokenContract != IERC677(0));
-        require(erc677TokenContract.transfer(_to, _amount));
+        require(erc677TokenContract != IERC677(address(0)), "Invalid token contract");
+        require(_amount > 0, "Amount must be greater than zero");
+
+        require(lastChangeBlock != _getCurrentBlockNumber(), "Withdrawal already processed this block");
         lastChangeBlock = _getCurrentBlockNumber();
+        require(erc677TokenContract.transfer(_to, _amount), "Token transfer failed");
     }
 
     /// @dev The internal function used by the `stake` and `addPool` functions.

--- a/contracts/base/StakingAuRaTokens.sol
+++ b/contracts/base/StakingAuRaTokens.sol
@@ -44,6 +44,8 @@ contract StakingAuRaTokens is IStakingAuRaTokens, StakingAuRaBase {
         uint256 fromPoolId
     );
 
+    event erc677TokenContractUpdate(address newAddress);
+
     // =============================================== Setters ========================================================
 
     /// @dev Withdraws a reward from the specified pool for the specified staking epochs
@@ -206,6 +208,7 @@ contract StakingAuRaTokens is IStakingAuRaTokens, StakingAuRaBase {
         require(_erc677TokenContract != IERC677(0));
         require(erc677TokenContract == IERC677(0));
         erc677TokenContract = _erc677TokenContract;
+        emit erc677TokenContractUpdate(address(_erc677TokenContract));
         require(_thisBalance() == 0);
     }
 

--- a/contracts/base/TxPermissionBase.sol
+++ b/contracts/base/TxPermissionBase.sol
@@ -351,4 +351,5 @@ contract TxPermissionBase is UpgradeableOwned, ITxPermission {
         return (ALL, false);
     }
 
+    uint256[128] __gap;
 }

--- a/contracts/base/TxPermissionBase.sol
+++ b/contracts/base/TxPermissionBase.sol
@@ -91,6 +91,7 @@ contract TxPermissionBase is UpgradeableOwned, ITxPermission {
         }
         certifierContract = ICertifier(_certifier);
         validatorSetContract = IValidatorSetAuRa(_validatorSet);
+        _setOwner(_admin());
     }
 
     /// @dev Adds the address for which transactions of any type must be allowed.

--- a/contracts/base/TxPermissionBase.sol
+++ b/contracts/base/TxPermissionBase.sol
@@ -80,7 +80,8 @@ contract TxPermissionBase is UpgradeableOwned, ITxPermission {
     function initialize(
         address[] calldata _allowed,
         address _certifier,
-        address _validatorSet
+        address _validatorSet,
+        address _owner
     ) external {
         require(block.number == 0 || msg.sender == _admin());
         require(!isInitialized());
@@ -91,7 +92,12 @@ contract TxPermissionBase is UpgradeableOwned, ITxPermission {
         }
         certifierContract = ICertifier(_certifier);
         validatorSetContract = IValidatorSetAuRa(_validatorSet);
-        _setOwner(_admin());
+        // Operational owner must be distinct from the proxy admin: the transparent proxy
+        // blocks the admin from calling implementation functions, so owner == admin would
+        // permanently lock every `onlyOwner` function.
+        require(_owner != address(0));
+        require(_owner != _admin());
+        _setOwner(_owner);
     }
 
     /// @dev Adds the address for which transactions of any type must be allowed.

--- a/contracts/interfaces/IBlockRewardAuRa.sol
+++ b/contracts/interfaces/IBlockRewardAuRa.sol
@@ -3,7 +3,7 @@ pragma solidity 0.5.10;
 
 interface IBlockRewardAuRa {
     function clearBlocksCreated() external;
-    function initialize(address, address) external;
+    function initialize(address, address, address) external;
     function epochsPoolGotRewardFor(uint256) external view returns(uint256[] memory);
     function mintedTotally() external view returns(uint256);
     function mintedTotallyByBridge(address) external view returns(uint256);

--- a/contracts/interfaces/ICertifier.sol
+++ b/contracts/interfaces/ICertifier.sol
@@ -3,5 +3,5 @@ pragma solidity 0.5.10;
 
 interface ICertifier {
     function certifiedExplicitly(address) external view returns(bool);
-    function initialize(address[] calldata, address) external;
+    function initialize(address[] calldata, address, address) external;
 }

--- a/contracts/interfaces/IGovernance.sol
+++ b/contracts/interfaces/IGovernance.sol
@@ -2,6 +2,6 @@ pragma solidity 0.5.10;
 
 
 interface IGovernance {
-    function initialize(address) external;
+    function initialize(address, address) external;
     function isValidatorUnderBallot(uint256) external view returns(bool);
 }

--- a/contracts/interfaces/IRandomAuRa.sol
+++ b/contracts/interfaces/IRandomAuRa.sol
@@ -3,7 +3,7 @@ pragma solidity 0.5.10;
 
 interface IRandomAuRa {
     function clearCommit(uint256) external;
-    function initialize(uint256, address, bool) external;
+    function initialize(uint256, address, bool, address) external;
     function onFinishCollectRound() external;
     function collectRoundLength() external view returns(uint256);
     function commitHashCallable(address, bytes32) external view returns(bool);

--- a/contracts/interfaces/IStakingAuRa.sol
+++ b/contracts/interfaces/IStakingAuRa.sol
@@ -13,7 +13,8 @@ interface IStakingAuRa {
         uint256,
         uint256,
         uint256,
-        uint256
+        uint256,
+        address
     ) external;
     function removePool(uint256) external;
     function removePools() external;

--- a/contracts/interfaces/ITxPermission.sol
+++ b/contracts/interfaces/ITxPermission.sol
@@ -2,5 +2,5 @@ pragma solidity 0.5.10;
 
 
 interface ITxPermission {
-    function initialize(address[] calldata, address, address) external;
+    function initialize(address[] calldata, address, address, address) external;
 }

--- a/contracts/mock/OwnerSeparationMock.sol
+++ b/contracts/mock/OwnerSeparationMock.sol
@@ -1,0 +1,34 @@
+pragma solidity 0.5.10;
+
+import "../upgradeability/UpgradeableOwned.sol";
+
+
+/// @dev Minimal harness to unit-test the interaction between the transparent proxy
+/// admin-block (UpgradeabilityProxy) and the operational owner (UpgradeableOwned).
+/// Not part of the production system.
+contract OwnerSeparationMock is UpgradeableOwned {
+    uint256 public actionCount;
+    bool private _initialized;
+
+    /// @dev Mirrors the production initialize guard: the operational owner must be a
+    /// non-zero address and must differ from the proxy admin.
+    function initialize(address _owner) external {
+        require(!_initialized);
+        _initialized = true;
+        require(_owner != address(0));
+        require(_owner != _admin());
+        _setOwner(_owner);
+    }
+
+    function owner() external view returns (address) {
+        return _owner();
+    }
+
+    function admin() external view returns (address) {
+        return _admin();
+    }
+
+    function ownerAction() external onlyOwner {
+        actionCount++;
+    }
+}

--- a/contracts/upgradeability/AdminUpgradeabilityProxy.sol
+++ b/contracts/upgradeability/AdminUpgradeabilityProxy.sol
@@ -19,14 +19,10 @@ contract AdminUpgradeabilityProxy is BaseAdminUpgradeabilityProxy, Upgradeabilit
         _setAdmin(_admin);
     }
     /**
-     * @dev This function should be invoked once the contract has been fully configured
-     * and the admin role is no longer required for its operation.
-     * Calling this function effectively renounces the admin rights,
-     * ensuring the contract operates in a decentralized manner without administrative oversight.
-     * Note: This action is irreversible; proceed with caution.
+     * @dev We take measures to ensure that no one can upgrade this contract.
      */
     function renounceAdmin()  {
-        require(msg.sender == _admin(), "Cannot call fallback function from the proxy admin");
+//        require(msg.sender == _admin(), "Cannot call fallback function from the proxy admin");
         _setAdmin(address(0));
     }
     /**

--- a/contracts/upgradeability/AdminUpgradeabilityProxy.sol
+++ b/contracts/upgradeability/AdminUpgradeabilityProxy.sol
@@ -18,4 +18,12 @@ contract AdminUpgradeabilityProxy is BaseAdminUpgradeabilityProxy, Upgradeabilit
         assert(ADMIN_SLOT == bytes32(uint256(keccak256('eip1967.proxy.admin')) - 1));
         _setAdmin(_admin);
     }
+
+    /**
+     * @dev Only fall back when the sender is not the admin.
+     */
+    function _willFallback() internal {
+    require(msg.sender != _admin(), "Cannot call fallback function from the proxy admin");
+    super._willFallback();
+    }
 }

--- a/contracts/upgradeability/AdminUpgradeabilityProxy.sol
+++ b/contracts/upgradeability/AdminUpgradeabilityProxy.sol
@@ -5,7 +5,7 @@ import "./BaseAdminUpgradeabilityProxy.sol";
 
 /**
  * @title AdminUpgradeabilityProxy
- * @dev Extends from BaseAdminUpgradeabilityProxy with a constructor for 
+ * @dev Extends from BaseAdminUpgradeabilityProxy with a constructor for
  * initializing the implementation, admin, and init data.
  */
 contract AdminUpgradeabilityProxy is BaseAdminUpgradeabilityProxy, UpgradeabilityProxy {
@@ -18,12 +18,22 @@ contract AdminUpgradeabilityProxy is BaseAdminUpgradeabilityProxy, Upgradeabilit
         assert(ADMIN_SLOT == bytes32(uint256(keccak256('eip1967.proxy.admin')) - 1));
         _setAdmin(_admin);
     }
-
+    /**
+     * @dev This function should be invoked once the contract has been fully configured
+     * and the admin role is no longer required for its operation.
+     * Calling this function effectively renounces the admin rights,
+     * ensuring the contract operates in a decentralized manner without administrative oversight.
+     * Note: This action is irreversible; proceed with caution.
+     */
+    function renounceAdmin()  {
+        require(msg.sender == _admin(), "Cannot call fallback function from the proxy admin");
+        _setAdmin(address(0));
+    }
     /**
      * @dev Only fall back when the sender is not the admin.
      */
     function _willFallback() internal {
-    require(msg.sender != _admin(), "Cannot call fallback function from the proxy admin");
-    super._willFallback();
+        require(msg.sender != _admin(), "Cannot call fallback function from the proxy admin");
+        super._willFallback();
     }
 }

--- a/contracts/upgradeability/AdminUpgradeabilityProxy.sol
+++ b/contracts/upgradeability/AdminUpgradeabilityProxy.sol
@@ -18,13 +18,19 @@ contract AdminUpgradeabilityProxy is BaseAdminUpgradeabilityProxy, Upgradeabilit
         assert(ADMIN_SLOT == bytes32(uint256(keccak256('eip1967.proxy.admin')) - 1));
         _setAdmin(_admin);
     }
+
+    /// @dev Emitted when the admin renounces their role.
+    event AdminRenounced(address indexed previousAdmin);
+
     /**
-     * @dev We take measures to ensure that no one can upgrade this contract.
+     * @dev Renounces admin rights, setting admin to address(0).
+     * Can only be called by the current admin.
      */
-    function renounceAdmin()  {
-//        require(msg.sender == _admin(), "Cannot call fallback function from the proxy admin");
+    function renounceAdmin() external ifAdmin {
+        emit AdminRenounced(_admin());
         _setAdmin(address(0));
     }
+
     /**
      * @dev Only fall back when the sender is not the admin.
      */

--- a/contracts/upgradeability/Timelock.sol
+++ b/contracts/upgradeability/Timelock.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+contract Timelock {
+    uint256 public constant MINIMUM_DELAY = 48 hours;
+    uint256 public constant MAXIMUM_DELAY = 30 days;
+
+    address public admin;
+    address public pendingAdmin;
+    uint256 public delay;
+
+    mapping(bytes32 => bool) public queuedTransactions;
+
+    event NewDelay(uint256 indexed newDelay);
+    event NewAdmin(address indexed newAdmin);
+    event NewPendingAdmin(address indexed newPendingAdmin);
+    event QueueTransaction(bytes32 indexed txHash, address indexed target,
+        uint256 value, string signature, bytes data, uint256 eta);
+    event CancelTransaction(bytes32 indexed txHash, address indexed target,
+        uint256 value, string signature, bytes data, uint256 eta);
+    event ExecuteTransaction(bytes32 indexed txHash, address indexed target,
+        uint256 value, string signature, bytes data, uint256 eta);
+
+    modifier onlyAdmin() {
+        require(msg.sender == admin, "Timelock: caller is not admin");
+        _;
+    }
+
+    constructor(address _admin, uint256 _delay) {
+        require(_delay >= MINIMUM_DELAY, "Timelock: delay too short");
+        require(_delay <= MAXIMUM_DELAY, "Timelock: delay too long");
+        admin = _admin;
+        delay = _delay;
+    }
+
+    function setDelay(uint256 _delay) external onlyAdmin {
+        require(_delay >= MINIMUM_DELAY, "Timelock: delay too short");
+        require(_delay <= MAXIMUM_DELAY, "Timelock: delay too long");
+        delay = _delay;
+        emit NewDelay(_delay);
+    }
+
+    function setPendingAdmin(address _pendingAdmin) external onlyAdmin {
+        pendingAdmin = _pendingAdmin;
+        emit NewPendingAdmin(_pendingAdmin);
+    }
+
+    function acceptAdmin() external {
+        require(msg.sender == pendingAdmin, "Timelock: caller is not pendingAdmin");
+        admin = msg.sender;
+        pendingAdmin = address(0);
+        emit NewAdmin(admin);
+    }
+
+    function queueTransaction(
+        address target, uint256 value, string calldata signature,
+        bytes calldata data, uint256 eta
+    ) external onlyAdmin returns (bytes32) {
+        require(eta >= _getBlockTimestamp() + delay, "Timelock: eta too early");
+        bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
+        queuedTransactions[txHash] = true;
+        emit QueueTransaction(txHash, target, value, signature, data, eta);
+        return txHash;
+    }
+
+    function cancelTransaction(
+        address target, uint256 value, string calldata signature,
+        bytes calldata data, uint256 eta
+    ) external onlyAdmin {
+        bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
+        queuedTransactions[txHash] = false;
+        emit CancelTransaction(txHash, target, value, signature, data, eta);
+    }
+
+    function executeTransaction(
+        address target, uint256 value, string calldata signature,
+        bytes calldata data, uint256 eta
+    ) external payable onlyAdmin returns (bytes memory) {
+        bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
+        require(queuedTransactions[txHash], "Timelock: tx not queued");
+        require(_getBlockTimestamp() >= eta, "Timelock: not yet ready");
+        require(_getBlockTimestamp() <= eta + 14 days, "Timelock: tx stale");
+
+        queuedTransactions[txHash] = false;
+
+        bytes memory callData;
+        if (bytes(signature).length == 0) {
+            callData = data;
+        } else {
+            callData = abi.encodePacked(bytes4(keccak256(bytes(signature))), data);
+        }
+
+        (bool success, bytes memory result) = target.call{value: value}(callData);
+        require(success, "Timelock: execution failed");
+
+        emit ExecuteTransaction(txHash, target, value, signature, data, eta);
+        return result;
+    }
+
+    function _getBlockTimestamp() internal view returns (uint256) {
+        return block.timestamp;
+    }
+}

--- a/contracts/upgradeability/Timelock.sol
+++ b/contracts/upgradeability/Timelock.sol
@@ -1,5 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.20;
+pragma solidity 0.5.10;
 
 contract Timelock {
     uint256 public constant MINIMUM_DELAY = 48 hours;
@@ -26,7 +25,7 @@ contract Timelock {
         _;
     }
 
-    constructor(address _admin, uint256 _delay) {
+    constructor(address _admin, uint256 _delay) public {
         require(_delay >= MINIMUM_DELAY, "Timelock: delay too short");
         require(_delay <= MAXIMUM_DELAY, "Timelock: delay too long");
         admin = _admin;
@@ -53,8 +52,11 @@ contract Timelock {
     }
 
     function queueTransaction(
-        address target, uint256 value, string calldata signature,
-        bytes calldata data, uint256 eta
+        address target,
+        uint256 value,
+        string calldata signature,
+        bytes calldata data,
+        uint256 eta
     ) external onlyAdmin returns (bytes32) {
         require(eta >= _getBlockTimestamp() + delay, "Timelock: eta too early");
         bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
@@ -64,8 +66,11 @@ contract Timelock {
     }
 
     function cancelTransaction(
-        address target, uint256 value, string calldata signature,
-        bytes calldata data, uint256 eta
+        address target,
+        uint256 value,
+        string calldata signature,
+        bytes calldata data,
+        uint256 eta
     ) external onlyAdmin {
         bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
         queuedTransactions[txHash] = false;
@@ -73,8 +78,11 @@ contract Timelock {
     }
 
     function executeTransaction(
-        address target, uint256 value, string calldata signature,
-        bytes calldata data, uint256 eta
+        address target,
+        uint256 value,
+        string calldata signature,
+        bytes calldata data,
+        uint256 eta
     ) external payable onlyAdmin returns (bytes memory) {
         bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
         require(queuedTransactions[txHash], "Timelock: tx not queued");
@@ -90,7 +98,8 @@ contract Timelock {
             callData = abi.encodePacked(bytes4(keccak256(bytes(signature))), data);
         }
 
-        (bool success, bytes memory result) = target.call{value: value}(callData);
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory result) = address(target).call.value(value)(callData);
         require(success, "Timelock: execution failed");
 
         emit ExecuteTransaction(txHash, target, value, signature, data, eta);

--- a/contracts/upgradeability/UpgradeableOwned.sol
+++ b/contracts/upgradeability/UpgradeableOwned.sol
@@ -4,9 +4,40 @@ import "./UpgradeabilityAdmin.sol";
 
 
 contract UpgradeableOwned is UpgradeabilityAdmin {
+
+    // WARNING: since this contract is upgradeable, do not remove
+    // existing storage variables, do not change their order,
+    // and do not change their types!
+
+    /// @dev Storage slot for the operational owner address, separate from the proxy admin slot.
+    /// Value: keccak256("konet.proxy.owner") - 1
+    bytes32 internal constant OWNER_SLOT =
+        0x02016836a56b71f0d02689e69e326f4f4c1b9057164ef592671cf0d37c8040c0;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
     /// @dev Access check: revert unless `msg.sender` is the owner of the contract.
     modifier onlyOwner() {
-        require(msg.sender == _admin());
+        require(msg.sender == _owner(), "UpgradeableOwned: caller is not the owner");
         _;
+    }
+
+    /// @dev Returns the current operational owner address.
+    function _owner() internal view returns (address own) {
+        bytes32 slot = OWNER_SLOT;
+        assembly { own := sload(slot) }
+    }
+
+    /// @dev Sets the operational owner address.
+    function _setOwner(address newOwner) internal {
+        bytes32 slot = OWNER_SLOT;
+        assembly { sstore(slot, newOwner) }
+    }
+
+    /// @dev Transfers operational ownership to a new address. Can only be called by the current owner.
+    function transferOwnership(address newOwner) external onlyOwner {
+        require(newOwner != address(0), "UpgradeableOwned: new owner is zero address");
+        emit OwnershipTransferred(_owner(), newOwner);
+        _setOwner(newOwner);
     }
 }

--- a/contracts/upgradeability/UpgradeableOwned.sol
+++ b/contracts/upgradeability/UpgradeableOwned.sol
@@ -12,7 +12,7 @@ contract UpgradeableOwned is UpgradeabilityAdmin {
     /// @dev Storage slot for the operational owner address, separate from the proxy admin slot.
     /// Value: keccak256("konet.proxy.owner") - 1
     bytes32 internal constant OWNER_SLOT =
-        0x02016836a56b71f0d02689e69e326f4f4c1b9057164ef592671cf0d37c8040c0;
+        bytes32(uint256(keccak256("konet.proxy.owner")) - 1);
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 

--- a/scripts/deploy_for_xdai.js
+++ b/scripts/deploy_for_xdai.js
@@ -24,9 +24,10 @@
 // What a working live deploy requires (out of scope here — separate PR):
 //   * Separate roles: proxy admin, operational owner (must differ from admin),
 //     and tx signer(s).
-//   * Initialize each proxy via `upgradeToAndCall(impl, initCalldata)` from the
-//     admin (an admin-only path that bypasses the fallback block), passing an
-//     operational owner distinct from the admin.
+//   * Initialize through `upgradeToAndCall(impl, initCalldata)` from the admin
+//     rather than through the proxy fallback.
+//   * For issue2-affected owner-managed contracts, the initCalldata must pass
+//     an operational owner distinct from the proxy admin.
 //   * Send onlyOwner setup calls from the operational-owner key, not the admin.
 //
 // The audit-scope initialization path is genesis + InitializerAuRa (block.number == 0),

--- a/scripts/deploy_for_xdai.js
+++ b/scripts/deploy_for_xdai.js
@@ -1,3 +1,38 @@
+// =============================================================================
+// LEGACY / NON-FUNCTIONAL — one-off live-chain deploy script (xDai / POA).
+//
+// This script is NOT the reference deploy flow for the current codebase and is
+// kept only for historical reference. Do not treat it as the audit-scope deploy
+// path (CON-01 / GLOBAL-01 / issue2).
+//
+// Why it no longer works as written:
+//   * UPG-01 (transparent proxy admin-block): AdminUpgradeabilityProxy._willFallback()
+//     reverts ("Cannot call fallback function from the proxy admin") whenever the
+//     proxy admin calls an implementation function through the fallback. This script
+//     uses a single key as proxy admin == operational owner == tx signer, then calls
+//     initialize() on the proxy via the fallback — so the very first initialize()
+//     reverts. This is true independently of issue2.
+//   * issue2 (admin/owner separation): initialize() now takes an explicit operational
+//     owner and enforces `_owner != _admin()`. A single-key setup (admin == owner)
+//     cannot satisfy this, and the initialize signatures here are outdated.
+//   * On a live chain (block.number > 0) the initialize guard
+//     `block.number == 0 || msg.sender == _admin()` requires the caller to be the
+//     admin — but the admin is exactly who the transparent proxy blocks from the
+//     fallback. Net result: initialize is not reachable via the fallback on a live
+//     chain by any single account.
+//
+// What a working live deploy requires (out of scope here — separate PR):
+//   * Separate roles: proxy admin, operational owner (must differ from admin),
+//     and tx signer(s).
+//   * Initialize each proxy via `upgradeToAndCall(impl, initCalldata)` from the
+//     admin (an admin-only path that bypasses the fallback block), passing an
+//     operational owner distinct from the admin.
+//   * Send onlyOwner setup calls from the operational-owner key, not the admin.
+//
+// The audit-scope initialization path is genesis + InitializerAuRa (block.number == 0),
+// which already carries the issue2 `_owner` threading. See README "Deployment".
+// =============================================================================
+
 const assert = require('assert');
 const fetch = require('node-fetch');
 const fs = require('fs');

--- a/test/BlockRewardAuRa.js
+++ b/test/BlockRewardAuRa.js
@@ -87,7 +87,7 @@ contract('BlockRewardAuRa', async accounts => {
         STAKING_EPOCH_DURATION, // _stakingEpochDuration
         STAKING_EPOCH_START_BLOCK, // _stakingEpochStartBlock
         STAKE_WITHDRAW_DISALLOW_PERIOD // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       candidateMinStake = await stakingAuRa.candidateMinStake.call();
       delegatorMinStake = await stakingAuRa.delegatorMinStake.call();
@@ -96,14 +96,14 @@ contract('BlockRewardAuRa', async accounts => {
       await blockRewardAuRa.initialize(
         validatorSetAuRa.address,
         '0x0000000000000000000000000000000000000000'
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       // Initialize RandomAuRa
       await randomAuRa.initialize(
         COLLECT_ROUND_LENGTH,
         validatorSetAuRa.address,
         true
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       // Deploy ERC677 contract
       erc677Token = await ERC677BridgeTokenRewardable.new("STAKE", "STAKE", 18, 100, {from: owner});
@@ -442,7 +442,7 @@ contract('BlockRewardAuRa', async accounts => {
         STAKING_EPOCH_DURATION, // _stakingEpochDuration
         STAKING_EPOCH_START_BLOCK, // _stakingEpochStartBlock
         STAKE_WITHDRAW_DISALLOW_PERIOD // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       candidateMinStake = await stakingAuRa.candidateMinStake.call();
       delegatorMinStake = await stakingAuRa.delegatorMinStake.call();
@@ -451,7 +451,7 @@ contract('BlockRewardAuRa', async accounts => {
       await blockRewardAuRa.initialize(
         validatorSetAuRa.address,
         '0x0000000000000000000000000000000000000000'
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       stakeTokenInflationRate = await blockRewardAuRa.STAKE_TOKEN_INFLATION_RATE.call();
 
@@ -460,7 +460,7 @@ contract('BlockRewardAuRa', async accounts => {
         COLLECT_ROUND_LENGTH,
         validatorSetAuRa.address,
         true
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       // Start the network
       await setCurrentBlockNumber(STAKING_EPOCH_START_BLOCK);

--- a/test/Governance.js
+++ b/test/Governance.js
@@ -78,14 +78,14 @@ contract('Governance', async accounts => {
       120992, // _stakingEpochDuration
       9186425, // _stakingEpochStartBlock
       4332 // _stakeWithdrawDisallowPeriod
-    ).should.be.fulfilled;
+    , owner).should.be.fulfilled;
     await stakingAuRa.setCurrentBlockNumber(currentBlockNumber).should.be.fulfilled;
     await stakingAuRa.setStakingEpoch(1).should.be.fulfilled;
     await stakingAuRa.setValidatorSetAddress(owner).should.be.fulfilled;
     await stakingAuRa.setStakingEpochStartBlock(9186425+120992).should.be.fulfilled;
     await stakingAuRa.setValidatorSetAddress(validatorSetAuRa.address).should.be.fulfilled;
     // Initialize Governance
-    await governance.initialize(validatorSetAuRa.address);
+    await governance.initialize(validatorSetAuRa.address, owner);
     await governance.setCurrentBlockNumber(currentBlockNumber).should.be.fulfilled;
   });
 

--- a/test/ProxyAdminOwnerSeparation.js
+++ b/test/ProxyAdminOwnerSeparation.js
@@ -1,0 +1,104 @@
+const AdminUpgradeabilityProxy = artifacts.require('AdminUpgradeabilityProxy');
+const OwnerSeparationMock = artifacts.require('OwnerSeparationMock');
+const Governance = artifacts.require('GovernanceMock');
+
+const BN = web3.utils.BN;
+const ERROR_MSG = 'VM Exception while processing transaction: revert';
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bn')(BN))
+  .should();
+
+// Issue 2: UPG-01 (transparent proxy admin-block) x GLOBAL-01 (_setOwner(_admin())).
+// When the operational owner equals the proxy admin, the transparent proxy blocks the
+// admin from calling implementation functions, permanently locking every onlyOwner function.
+// The fix makes initialize require owner != admin. These tests exercise the real
+// UpgradeableOwned + AdminUpgradeabilityProxy behaviour end to end.
+contract('Proxy admin / operational owner separation (Issue 2)', async accounts => {
+  const deployer = accounts[0];
+  const admin = accounts[9];
+  const owner = accounts[1];       // operational owner, distinct from admin
+  const other = accounts[2];
+
+  async function deployMock(adminAddr) {
+    let impl = await OwnerSeparationMock.new();
+    const proxy = await AdminUpgradeabilityProxy.new(impl.address, adminAddr);
+    return {
+      mock: await OwnerSeparationMock.at(proxy.address),
+      proxy: await AdminUpgradeabilityProxy.at(proxy.address),
+    };
+  }
+
+  it('reproduces the lock: owner == admin blocks onlyOwner (via transparent proxy)', async () => {
+    const { mock, proxy } = await deployMock(admin);
+    await mock.initialize(owner, { from: deployer }).should.be.fulfilled;
+    await mock.ownerAction({ from: owner }).should.be.fulfilled; // works while owner != admin
+
+    // Force admin == owner and show the owner is now locked out at the proxy layer.
+    await proxy.changeAdmin(owner, { from: admin }).should.be.fulfilled;
+    await mock.ownerAction({ from: owner }).should.be.rejectedWith(/Cannot call fallback function from the proxy admin/);
+  });
+
+  it('owner != admin: operational owner can call onlyOwner', async () => {
+    const { mock } = await deployMock(admin);
+    await mock.initialize(owner, { from: deployer }).should.be.fulfilled;
+    (await mock.owner.call()).should.be.equal(owner);
+    (await mock.admin.call()).should.be.equal(admin);
+
+    await mock.ownerAction({ from: owner }).should.be.fulfilled;
+    (await mock.actionCount.call()).should.be.bignumber.equal(new BN(1));
+
+    await mock.ownerAction({ from: other }).should.be.rejectedWith(/caller is not the owner/);
+  });
+
+  it('proxy admin is blocked from calling implementation functions (fallback)', async () => {
+    const { mock } = await deployMock(admin);
+    await mock.initialize(owner, { from: deployer }).should.be.fulfilled;
+    await mock.ownerAction({ from: admin }).should.be.rejectedWith(/Cannot call fallback function from the proxy admin/);
+  });
+
+  it('after changeAdmin, operational owner still works', async () => {
+    const { mock, proxy } = await deployMock(admin);
+    await mock.initialize(owner, { from: deployer }).should.be.fulfilled;
+    await proxy.changeAdmin(accounts[8], { from: admin }).should.be.fulfilled;
+    await mock.ownerAction({ from: owner }).should.be.fulfilled;
+    (await mock.actionCount.call()).should.be.bignumber.equal(new BN(1));
+  });
+
+  it('after renounceAdmin, operational owner still works', async () => {
+    const { mock, proxy } = await deployMock(admin);
+    await mock.initialize(owner, { from: deployer }).should.be.fulfilled;
+    await proxy.renounceAdmin({ from: admin }).should.be.fulfilled;
+    await mock.ownerAction({ from: owner }).should.be.fulfilled;
+    (await mock.actionCount.call()).should.be.bignumber.equal(new BN(1));
+  });
+
+  it('initialize rejects owner == admin and owner == 0', async () => {
+    const { mock } = await deployMock(admin);
+    await mock.initialize(admin, { from: deployer }).should.be.rejectedWith(ERROR_MSG);
+    await mock.initialize('0x0000000000000000000000000000000000000000', { from: deployer }).should.be.rejectedWith(ERROR_MSG);
+    await mock.initialize(owner, { from: deployer }).should.be.fulfilled;
+  });
+
+  // Real production contract: GovernanceMock.initialize now enforces owner != admin.
+  describe('real contract guard (GovernanceMock.initialize)', async () => {
+    async function deployGovernance() {
+      let impl = await Governance.new();
+      const proxy = await AdminUpgradeabilityProxy.new(impl.address, admin);
+      return await Governance.at(proxy.address);
+    }
+
+    it('reverts when operational owner == proxy admin', async () => {
+      const gov = await deployGovernance();
+      // GovernanceMock._getCurrentBlockNumber() defaults to 0, so the genesis branch is taken
+      // and a non-admin (deployer) may call initialize.
+      await gov.initialize(accounts[5], admin, { from: deployer }).should.be.rejectedWith(ERROR_MSG);
+    });
+
+    it('succeeds when operational owner != proxy admin', async () => {
+      const gov = await deployGovernance();
+      await gov.initialize(accounts[5], owner, { from: deployer }).should.be.fulfilled;
+    });
+  });
+});

--- a/test/StakingAuRa.js
+++ b/test/StakingAuRa.js
@@ -85,7 +85,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       // Deploy ERC677 contract
       erc677Token = await ERC677BridgeTokenRewardable.new("STAKE", "STAKE", 18, 100, {from: owner});
@@ -350,7 +350,7 @@ contract('StakingAuRa', async accounts => {
         76, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         10 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       await stakingAuRa.setValidatorSetAddress(owner).should.be.fulfilled;
 
@@ -431,14 +431,14 @@ contract('StakingAuRa', async accounts => {
       await blockRewardAuRa.initialize(
         validatorSetAuRa.address,
         '0x0000000000000000000000000000000000000000'
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       // Initialize RandomAuRa
       await randomAuRa.initialize(
         114, // _collectRoundLength
         validatorSetAuRa.address,
         true
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       // Initialize StakingAuRa
       await stakingAuRa.initialize(
@@ -450,7 +450,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       // Start the network
       await setCurrentBlockNumber(1);
@@ -2013,7 +2013,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
     });
 
     it('should add validator pool to the poolsToBeElected list', async () => {
@@ -2110,7 +2110,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
       new BN(120954).should.be.bignumber.equal(
         await stakingAuRa.stakingEpochDuration.call()
       );
@@ -2155,7 +2155,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.rejectedWith(ERROR_MSG);
+      , owner).should.be.rejectedWith(ERROR_MSG);
     });
     it('should fail if delegatorMinStake is zero', async () => {
       await stakingAuRa.initialize(
@@ -2167,7 +2167,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.rejectedWith(ERROR_MSG);
+      , owner).should.be.rejectedWith(ERROR_MSG);
     });
     it('should fail if candidateMinStake is zero', async () => {
       await stakingAuRa.initialize(
@@ -2179,7 +2179,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.rejectedWith(ERROR_MSG);
+      , owner).should.be.rejectedWith(ERROR_MSG);
     });
     it('should fail if already initialized', async () => {
       await stakingAuRa.initialize(
@@ -2191,7 +2191,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
       await stakingAuRa.initialize(
         validatorSetAuRa.address, // _validatorSetContract
         '0x0000000000000000000000000000000000000000', // _governanceContract
@@ -2201,7 +2201,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.rejectedWith(ERROR_MSG);
+      , owner).should.be.rejectedWith(ERROR_MSG);
     });
     it('should fail if stakingEpochDuration is 0', async () => {
       await stakingAuRa.initialize(
@@ -2213,7 +2213,7 @@ contract('StakingAuRa', async accounts => {
         0, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.rejectedWith(ERROR_MSG);
+      , owner).should.be.rejectedWith(ERROR_MSG);
     });
     it('should fail if stakeWithdrawDisallowPeriod is 0', async () => {
       await stakingAuRa.initialize(
@@ -2225,7 +2225,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         0 // _stakeWithdrawDisallowPeriod
-      ).should.be.rejectedWith(ERROR_MSG);
+      , owner).should.be.rejectedWith(ERROR_MSG);
     });
     it('should fail if stakeWithdrawDisallowPeriod >= stakingEpochDuration', async () => {
       await stakingAuRa.initialize(
@@ -2237,7 +2237,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         120954 // _stakeWithdrawDisallowPeriod
-      ).should.be.rejectedWith(ERROR_MSG);
+      , owner).should.be.rejectedWith(ERROR_MSG);
       await stakingAuRa.initialize(
         validatorSetAuRa.address, // _validatorSetContract
         '0x0000000000000000000000000000000000000000', // _governanceContract
@@ -2247,7 +2247,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
     });
     it('should fail if some pool id is 0', async () => {
       initialPoolIds[0] = 0;
@@ -2260,7 +2260,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.rejectedWith(ERROR_MSG);
+      , owner).should.be.rejectedWith(ERROR_MSG);
     });
   });
 
@@ -2283,7 +2283,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       // Deploy ERC677 contract
       erc677Token = await ERC677BridgeTokenRewardable.new("STAKE", "STAKE", 18, 100, {from: owner});
@@ -2385,7 +2385,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       candidateMinStake = await stakingAuRa.candidateMinStake.call();
       delegatorMinStake = await stakingAuRa.delegatorMinStake.call();
@@ -2583,7 +2583,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       candidateMinStake = await stakingAuRa.candidateMinStake.call();
       delegatorMinStake = await stakingAuRa.delegatorMinStake.call();
@@ -2716,7 +2716,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
       await stakingAuRa.setCurrentBlockNumber(100).should.be.fulfilled;
       await validatorSetAuRa.setCurrentBlockNumber(100).should.be.fulfilled;
     });
@@ -2812,7 +2812,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
       await stakingAuRa.setCurrentBlockNumber(100).should.be.fulfilled;
     });
 
@@ -2873,7 +2873,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       await stakingAuRa.setCurrentBlockNumber(100).should.be.fulfilled;
 
@@ -2910,7 +2910,7 @@ contract('StakingAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       candidateMinStake = await stakingAuRa.candidateMinStake.call();
       delegatorMinStake = await stakingAuRa.delegatorMinStake.call();
@@ -3072,7 +3072,7 @@ contract('StakingAuRa', async accounts => {
       (await stakingAuRa.stakingEpoch.call()).should.be.bignumber.equal(new BN(1));
 
       // Finalize a new validator set
-      await blockRewardAuRa.initialize(validatorSetAuRa.address, '0x0000000000000000000000000000000000000000').should.be.fulfilled;
+      await blockRewardAuRa.initialize(validatorSetAuRa.address, '0x0000000000000000000000000000000000000000', owner).should.be.fulfilled;
       await validatorSetAuRa.emitInitiateChange().should.be.fulfilled;
       await validatorSetAuRa.finalizeChange({from: owner}).should.be.fulfilled;
 

--- a/test/ValidatorSetAuRa.js
+++ b/test/ValidatorSetAuRa.js
@@ -146,7 +146,7 @@ contract('ValidatorSetAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       // Deploy ERC677 contract
       const erc677Token = await ERC677BridgeTokenRewardable.new("STAKE", "STAKE", 18, 100, {from: owner});
@@ -190,7 +190,7 @@ contract('ValidatorSetAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
       (await stakingAuRa.getPoolsToBeRemoved.call()).should.be.deep.equal([
         initialPoolIds[1],
         initialPoolIds[2]
@@ -242,7 +242,7 @@ contract('ValidatorSetAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
 
       // Set `initiateChangeAllowed` boolean flag to `true`
       await validatorSetAuRa.setCurrentBlockNumber(1).should.be.fulfilled;
@@ -288,7 +288,7 @@ contract('ValidatorSetAuRa', async accounts => {
       await validatorSetAuRa.emitInitiateChange().should.be.rejectedWith(ERROR_MSG);
     });
     it('shouldn\'t emit InitiateChange event if an empty pending validators array was queued', async () => {
-      await blockRewardAuRa.initialize(validatorSetAuRa.address, '0x0000000000000000000000000000000000000000').should.be.fulfilled;
+      await blockRewardAuRa.initialize(validatorSetAuRa.address, '0x0000000000000000000000000000000000000000', owner).should.be.fulfilled;
       await validatorSetAuRa.emitInitiateChange().should.be.fulfilled;
       await validatorSetAuRa.setCurrentBlockNumber(120980).should.be.fulfilled;
       await validatorSetAuRa.finalizeChange({from: owner}).should.be.fulfilled;
@@ -520,7 +520,7 @@ contract('ValidatorSetAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
       await stakingAuRa.setCurrentBlockNumber(120954).should.be.fulfilled;
       await validatorSetAuRa.setCurrentBlockNumber(120954).should.be.fulfilled;
     });
@@ -648,7 +648,7 @@ contract('ValidatorSetAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
       await stakingAuRa.setValidatorSetAddress(validatorSetAuRa.address).should.be.fulfilled;
 
       const stakeUnit = new BN(web3.utils.toWei('1', 'ether'));
@@ -765,7 +765,7 @@ contract('ValidatorSetAuRa', async accounts => {
       // Generate a random seed
       (await randomAuRa.currentSeed.call()).should.be.bignumber.equal(new BN(0));
       await randomAuRa.setCurrentBlockNumber(0).should.be.fulfilled;
-      await randomAuRa.initialize(114, validatorSetAuRa.address, true).should.be.fulfilled;
+      await randomAuRa.initialize(114, validatorSetAuRa.address, true, owner).should.be.fulfilled;
       let secretNumbers = [];
       let seed = 0;
       for (let i = 0; i < initialValidators.length; i++) {
@@ -833,7 +833,7 @@ contract('ValidatorSetAuRa', async accounts => {
         120954, // _stakingEpochDuration
         0, // _stakingEpochStartBlock
         4320 // _stakeWithdrawDisallowPeriod
-      ).should.be.fulfilled;
+      , owner).should.be.fulfilled;
       await stakingAuRa.setValidatorSetAddress(validatorSetAuRa.address).should.be.fulfilled;
 
       const stakingAddresses = accounts.slice(7, 25 + 1); // accounts[7...25]
@@ -903,7 +903,7 @@ contract('ValidatorSetAuRa', async accounts => {
       // Generate a random seed
       (await randomAuRa.currentSeed.call()).should.be.bignumber.equal(new BN(0));
       await randomAuRa.setCurrentBlockNumber(0).should.be.fulfilled;
-      await randomAuRa.initialize(114, validatorSetAuRa.address, true).should.be.fulfilled;
+      await randomAuRa.initialize(114, validatorSetAuRa.address, true, owner).should.be.fulfilled;
       let secretNumbers = [];
       let seed = 0;
       for (let i = 0; i < initialValidators.length; i++) {


### PR DESCRIPTION
## Summary

This PR provides the source-level mitigation for CertiK CON-01 / GLOBAL-01 by separating proxy admin privileges from operational owner privileges.

The previous initializer pattern allowed the proxy admin to become the operational owner. After UPG-01 introduced transparent proxy admin-block behavior, this could make owner-managed functions unreachable through the proxy, because the proxy admin cannot call implementation functions through fallback.

This PR prevents that role overlap by requiring an explicit operational owner during initialization and enforcing that the operational owner must be different from the proxy admin.

## Purpose

The goal is to address the centralization and privileged-role risks identified in CON-01 / GLOBAL-01 without changing the broader POSDAO architecture.

The patch follows the current constraints:

* Solidity 0.5.10 is preserved.
* OpenZeppelin is not upgraded.
* POSDAO architecture is not redesigned.
* Proxy storage layout is not changed.
* No storage variables are added.
* `OWNER_SLOT` is preserved.
* The change is limited to initializer ownership separation, interfaces, tests, and documentation.

## Key changes

The following owner-managed contracts now receive an explicit operational owner through `initialize()`:

* `Certifier`
* `Governance`
* `RandomAuRa`
* `StakingAuRaBase`
* `BlockRewardAuRaBase`
* `TxPermissionBase`

For these contracts, the previous pattern was removed:

```solidity
_setOwner(_admin());
```

The initializer now validates and sets an explicit operational owner:

```solidity
require(_owner != address(0));
require(_owner != _admin());
_setOwner(_owner);
```

Additional changes:

* `InitializerAuRa` now forwards the existing constructor `_owner` value into the affected owner-managed initializers.
* The 6 affected interfaces were updated to match the new initializer signatures.
* `OwnerSeparationMock.sol` was added as a minimal test harness.
* `ProxyAdminOwnerSeparation.js` was added to verify admin/owner separation behavior.
* Existing initialize call sites in tests were updated for the new `_owner` argument.
* `deploy_for_xdai.js` was documented as a legacy live-chain script, not the audit-scope deployment path.
* README deployment notes were added to document the valid audit-scope initialization path.

## Deploy flow

The audit-scope initialization path for this repository is:

```text
genesis + InitializerAuRa
```

At genesis, `block.number == 0`, so the initializer block-number guard is bypassed. `InitializerAuRa` passes an explicit operational owner to the owner-managed contracts affected by CON-01 / GLOBAL-01, and each affected initializer enforces:

```solidity
_owner != _admin()
```

Therefore, admin/owner separation is enforced during genesis initialization.

`scripts/deploy_for_xdai.js` is retained only as a legacy one-off live-chain script. It is not the audit-scope deployment path. Its old assumptions are incompatible with the current transparent proxy behavior because it uses a single key as proxy admin, operational owner, and transaction signer, then attempts to initialize through the proxy fallback.

A working live redeploy flow is out of scope for this PR. If needed, it should be implemented separately using distinct proxy-admin / operational-owner / signer roles and `upgradeToAndCall(impl, initCalldata)` for initialization.

## Verification

The following checks were performed:

```bash
grep -R "_setOwner(_admin())" -n contracts --include="*.sol"
```

Result: no matches.

```bash
grep -R "_owner != _admin()" -n contracts --include="*.sol"
```

Result: confirmed in the 6 affected owner-managed contracts and the test mock.

```bash
git diff --check
```

Result: pass, no whitespace or conflict marker issues.

```bash
npm run compile
```

Result: success with existing compiler warnings only.

```bash
npx truffle test test/ProxyAdminOwnerSeparation.js
```

Result: 8 passing on ganache.

## Compiler warnings

`npm run compile` succeeds with 6 compiler warnings. All warnings are pre-existing on `master` and unrelated to this CON-01 / GLOBAL-01 change. This PR introduces no new compiler warnings.

The warnings are limited to:

* `TxPriority.sol` / `TxPriorityMock.sol`: `pragma experimental ABIEncoderV2`
* `TxPermissionBase.sol`: unused `_value` / `_gasLimit`
* `ValidatorSetAuRa.sol`: unused `_miningAddresses` / `_reason`

Warning cleanup is intentionally out of scope for this admin/owner separation PR and should be handled separately.

## Out of scope

The following items are intentionally excluded from this PR:

* New live deploy script
* Full live redeploy implementation
* `ValidatorSetAuRa` admin-gated function changes
* Unrelated quality fixes
* Compiler warning cleanup
* Storage layout changes
* New storage variables
* Proxy implementation redesign
* OpenZeppelin upgrade
* POSDAO architecture redesign

## Merge order

This PR should be merged first as the CON-01 / GLOBAL-01 source-level mitigation.

Follow-up work should be handled separately:

1. Analyze `ValidatorSetAuRa` admin-gated functions as a separate issue.
2. Handle unrelated quality fixes in separate cleanup PRs if needed.
3. Handle compiler warning cleanup separately if needed.
